### PR TITLE
Modifications to Edit mode with a second navbar

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -198,6 +198,8 @@ app.directive('dashboardApp', function (es, kbnIndex, Notifier, courier, AppStat
           $scope.$root.showDefaultMenu = false;
         } else if(newMode === DashboardViewMode.EDIT) {
           $scope.$root.showDefaultMenu = true;
+          //Close second nav
+          $scope.$root.closeSecondNav();
         }
       }
 

--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -47,8 +47,29 @@ uiRoutes
   .when(createDashboardEditUrl(':id'), {
     template: dashboardTemplate,
     resolve: {
-      dash: function (savedDashboards, Notifier, $route, $location, courier, kbnUrl, AppState) {
+      dash: function ($rootScope, savedDashboards, Notifier, $route, $location, courier, kbnUrl, AppState) {
         const id = $route.current.params.id;
+
+        //Search the panel in the menu to select it
+        var index = 0;
+        for(var key in $rootScope.metadash){
+            var value = $rootScope.metadash[key];
+            if(typeof value == 'object'){
+              for(var key2 in value){
+                if(value[key2] == id){
+                  $rootScope.itemClicked(index);
+                  break;
+                }
+              }
+            }else{
+              if(value == id){
+                $rootScope.itemClicked(index);
+                break;
+              }
+            }
+            index++;
+        };
+
         return savedDashboards.get(id)
           .catch((error) => {
             // Preserve BWC of v5.3.0 links for new, unsaved dashboards.

--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -86,7 +86,7 @@ app.directive('dashboardApp', function (Notifier, courier, AppState, timefilter,
         docTitle.change(dash.title);
       }
 
-      const dashboardState = new DashboardState(dash, AppState);
+      const dashboardState = new DashboardState(dash, AppState, $scope);
 
       // The 'previouslyStored' check is so we only update the time filter on dashboard open, not during
       // normal cross app navigation.

--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -69,7 +69,7 @@ uiRoutes
     }
   });
 
-app.directive('dashboardApp', function (Notifier, courier, AppState, timefilter, quickRanges, kbnUrl, confirmModal, Private) {
+app.directive('dashboardApp', function (es, kbnIndex, Notifier, courier, AppState, timefilter, quickRanges, kbnUrl, confirmModal, Private) {
   const brushEvent = Private(UtilsBrushEventProvider);
   const filterBarClickHandler = Private(FilterBarFilterBarClickHandlerProvider);
 
@@ -239,7 +239,23 @@ app.directive('dashboardApp', function (Notifier, courier, AppState, timefilter,
 
       const navActions = {};
       navActions[TopNavIds.EXIT_EDIT_MODE] = () => onChangeViewMode(DashboardViewMode.VIEW);
-      navActions[TopNavIds.ENTER_EDIT_MODE] = () => onChangeViewMode(DashboardViewMode.EDIT);
+      navActions[TopNavIds.ENTER_EDIT_MODE] = () => {
+        /* Force POST to see the HTTP login auth */
+        function allowLogin() {
+          return es.update({
+            index: kbnIndex,
+            type: 'checklogin',
+            id: 'checklogin',
+            body: {
+              doc: {}
+            }
+          });
+        }
+        allowLogin().then(function () { //results) {
+          //console.log('OK', results)
+          onChangeViewMode(DashboardViewMode.EDIT);
+        });
+      };
 
       updateViewMode(dashboardState.getViewMode());
 

--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -194,6 +194,11 @@ app.directive('dashboardApp', function (Notifier, courier, AppState, timefilter,
         $scope.topNavMenu = getTopNavConfig(newMode, navActions); // eslint-disable-line no-use-before-define
         dashboardState.switchViewMode(newMode);
         $scope.dashboardViewMode = newMode;
+        if(newMode === DashboardViewMode.VIEW) {
+          $scope.$root.showDefaultMenu = false;
+        } else if(newMode === DashboardViewMode.EDIT) {
+          $scope.$root.showDefaultMenu = true;
+        }
       }
 
       const onChangeViewMode = (newMode) => {

--- a/src/core_plugins/kibana/public/dashboard/dashboard_state.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard_state.js
@@ -9,7 +9,7 @@ import stateMonitorFactory  from 'ui/state_management/state_monitor_factory';
 import { createPanelState } from 'plugins/kibana/dashboard/panel/panel_state';
 import { getPersistedStateId } from 'plugins/kibana/dashboard/panel/panel_state';
 
-function getStateDefaults(dashboard) {
+function getStateDefaults(dashboard, scope) {
   return {
     title: dashboard.title,
     timeRestore: dashboard.timeRestore,
@@ -18,7 +18,7 @@ function getStateDefaults(dashboard) {
     uiState: dashboard.uiStateJSON ? JSON.parse(dashboard.uiStateJSON) : {},
     query: FilterUtils.getQueryFilterForDashboard(dashboard),
     filters: FilterUtils.getFilterBarsForDashboard(dashboard),
-    viewMode: dashboard.id ? DashboardViewMode.VIEW : DashboardViewMode.EDIT,
+    viewMode: dashboard.id ? checkEditView(dashboard, scope) : DashboardViewMode.EDIT,
   };
 }
 
@@ -30,6 +30,18 @@ function getStateDefaults(dashboard) {
  */
 function cleanFiltersForComparison(filters) {
   return _.map(filters, (filter) => _.omit(filter, ['$$hashKey', '$state']));
+}
+
+/**
+* Depending if the user is switching between dashboard, the Edit mode must be hold
+* @param scope {<Object>}
+* @returns {ViewMode}
+*/
+function checkEditView(dashboard, scope) {
+  if(scope && scope.$root.showDefaultMenu) {
+    return DashboardViewMode.EDIT;
+  }
+  return DashboardViewMode.VIEW;
 }
 
 /**
@@ -59,10 +71,10 @@ export class DashboardState {
    * @param savedDashboard {SavedDashboard}
    * @param AppState {AppState}
    */
-  constructor(savedDashboard, AppState) {
+  constructor(savedDashboard, AppState, scope) {
     this.savedDashboard = savedDashboard;
 
-    this.stateDefaults = getStateDefaults(this.savedDashboard);
+    this.stateDefaults = getStateDefaults(this.savedDashboard, scope);
 
     this.appState = new AppState(this.stateDefaults);
     this.uiState = this.appState.makeStateful('uiState');

--- a/src/ui/public/chrome/directives/global_nav/global_nav.html
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.html
@@ -33,14 +33,14 @@
   <!-- Links -->
   <div class="global-nav__links">
     <!-- Main apps -->
-    <!-- <div class="global-nav__links-section">
+    <div class="global-nav__links-section" ng-show="$root.showDefaultMenu">
       <app-switcher
         chrome="chrome"
       ></app-switcher>
-    </div -->
+    </div>
 
     <!-- Metadashboard Links: Bitergia hack -->
-    <div class="global-nav__links-section">
+    <div class="global-nav__links-section" ng-show="!$root.showDefaultMenu">
         <div class="global-nav-link" ng-repeat="(name, panel) in metadash">
           <!-- One level menu entry (no submenus) -->
           <span ng-if="panel.length">

--- a/src/ui/public/chrome/directives/global_nav/global_nav.html
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.html
@@ -41,11 +41,11 @@
 
     <!-- Metadashboard Links: Bitergia hack -->
     <div class="global-nav__links-section" ng-show="!$root.showDefaultMenu">
-        <div class="global-nav-link" ng-repeat="(name, panel) in metadash">
+        <div class="global-nav-link" ng-repeat="(name, panel) in $root.metadash">
           <!-- One level menu entry (no submenus) -->
           <span ng-if="panel.length">
             <a
-              class='global-nav-link__anchor' ng-href='{{panel}}' ng-click="itemClicked($index)">
+              class='global-nav-link__anchor' ng-href='{{panel}}' ng-click="$root.itemClicked($index)">
               <div class='global-nav-link__icon' ng-class="{ 'selected-item': $index == selectedItem }">
               <!-- testing icon -->
               <img class="global-nav-link__icon-image ng-scope"
@@ -83,7 +83,7 @@
               <ul style='list-style: none;'>
                 <li ng-repeat="(name, url) in actualPanel">
                   <a  class='global-nav-link__anchor'
-                    ng-href='#/dashboard/{{url}}' ng-click="itemClicked($parent.$index)">
+                    ng-href='#/dashboard/{{url}}' ng-click="$root.itemClicked($parent.$index)">
                     {{name}}</a>
                 </li>
               </ul>

--- a/src/ui/public/chrome/directives/global_nav/global_nav.html
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.html
@@ -1,6 +1,6 @@
 <nav
   class="global-nav"
-  ng-class="{'is-global-nav-open': isGlobalNavOpen}"
+  ng-class="{'is-global-nav-open': isGlobalNavOpen, 'is-second-nav-open': isSecondNavOpen}"
   ng-show="isVisible"
 >
 
@@ -59,7 +59,7 @@
           </span>
           <span ng-if="!panel.length">
             <!-- Menu entry with submenus -->
-            <a ng-click="showMenu =! showMenu"
+            <a ng-click="toggleSecondNav(panel, $event)"
               class='global-nav-link__anchor' href=''>
               <div class='global-nav-link__icon'>
               <!-- testing icon -->
@@ -71,17 +71,28 @@
                 {{name}}
               </div>
             </a>
-            <div ng-if="showMenu">
+            <!-- div ng-if="showMenu">
               <ul style='list-style: none;'>
                 <li ng-repeat="(name, url) in panel">
                   <a  class='global-nav-link__anchor'
                     href='#/dashboard/{{url}}'>{{name}}</a>
                 </li>
               </ul>
+            </div -->
+            <div class="second-nav-content" ng-if="panel == actualPanel">
+              <ul style='list-style: none;'>
+                <li ng-repeat="(name, url) in actualPanel">
+                  <a  class='global-nav-link__anchor'
+                    ng-href='#/dashboard/{{url}}' ng-click="toggleSecondNav(panel, $event)">
+                    {{name}}</a>
+                </li>
+              </ul>
             </div>
         </span>
       </div>
     </div>
+
+
 
     <div class="grimoirelab-link"
       style="

--- a/src/ui/public/chrome/directives/global_nav/global_nav.html
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.html
@@ -45,14 +45,14 @@
           <!-- One level menu entry (no submenus) -->
           <span ng-if="panel.length">
             <a
-              class='global-nav-link__anchor' href='{{panel}}'>
-              <div class='global-nav-link__icon'>
+              class='global-nav-link__anchor' ng-href='{{panel}}' ng-click="itemClicked($index)">
+              <div class='global-nav-link__icon' ng-class="{ 'selected-item': $index == selectedItem }">
               <!-- testing icon -->
               <img class="global-nav-link__icon-image ng-scope"
                 kbn-src="/plugins/kibana/assets/discover.svg"
                 src="/plugins/kibana/assets/discover.svg">
               </div>
-              <div class='global-nav-link__title'>
+              <div class='global-nav-link__title' ng-class="{ 'selected-item': $index == selectedItem }">
                 {{name}}
               </div>
             </a>
@@ -61,13 +61,13 @@
             <!-- Menu entry with submenus -->
             <a ng-click="toggleSecondNav(panel, $event)"
               class='global-nav-link__anchor' href=''>
-              <div class='global-nav-link__icon'>
+              <div class='global-nav-link__icon' ng-class="{ 'selected-item': $index == selectedItem }">
               <!-- testing icon -->
               <img class="global-nav-link__icon-image ng-scope"
                 kbn-src="/plugins/kibana/assets/discover.svg"
                 src="/plugins/kibana/assets/discover.svg">
               </div>
-              <div class='global-nav-link__title'>
+              <div class='global-nav-link__title' ng-class="{ 'selected-item': $index == selectedItem }">
                 {{name}}
               </div>
             </a>
@@ -83,7 +83,7 @@
               <ul style='list-style: none;'>
                 <li ng-repeat="(name, url) in actualPanel">
                   <a  class='global-nav-link__anchor'
-                    ng-href='#/dashboard/{{url}}' ng-click="toggleSecondNav(panel, $event)">
+                    ng-href='#/dashboard/{{url}}' ng-click="itemClicked($parent.$index)">
                     {{name}}</a>
                 </li>
               </ul>

--- a/src/ui/public/chrome/directives/global_nav/global_nav.js
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.js
@@ -82,6 +82,13 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       scope.itemClicked = ($index) => {
         scope.selectedItem = $index;
         //Close second nav if it was open
+        scope.$root.closeSecondNav();
+      };
+
+      /*
+      * Function that closes the second nav if it was open
+      */
+      scope.$root.closeSecondNav = () => {
         if(globalNavState.isSecondOpen()) {
           globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
           scope.actualPanel = undefined;

--- a/src/ui/public/chrome/directives/global_nav/global_nav.js
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.js
@@ -79,7 +79,7 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       * Function that changes the CSS of the item that was clicked
       */
       scope.selectedItem = 0;
-      scope.itemClicked = ($index) => {
+      scope.$root.itemClicked = ($index) => {
         scope.selectedItem = $index;
         //Close second nav if it was open
         scope.$root.closeSecondNav();
@@ -111,7 +111,7 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       }
 
       getMetaDashboards().then(function (results) {
-        scope.metadash = results.hits[0]._source;
+        scope.$root.metadash = results.hits[0]._source;
       });
 
     }

--- a/src/ui/public/chrome/directives/global_nav/global_nav.js
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.js
@@ -26,6 +26,8 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       // App switcher functionality.
       function updateGlobalNav() {
         const isOpen = globalNavState.isOpen();
+        const isSecondOpen = globalNavState.isSecondOpen();
+        scope.isSecondNavOpen = isSecondOpen;
         scope.isGlobalNavOpen = isOpen;
         scope.globalNavToggleButton = {
           classes: isOpen ? 'global-nav-link--close' : undefined,
@@ -46,6 +48,31 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       scope.toggleGlobalNav = event => {
         event.preventDefault();
         globalNavState.setOpen(!globalNavState.isOpen());
+        if(globalNavState.isSecondOpen()){
+          globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
+          scope.actualPanel = undefined;
+        }
+      };
+
+      scope.toggleSecondNav = (panel, event) => {
+        //Open first nav-bar
+        if(!globalNavState.isOpen()){
+          globalNavState.setOpen(!globalNavState.isOpen())
+        }
+        //If clicking in the same panel, it must be open/close
+        if(panel == scope.actualPanel){
+          globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
+          if(!globalNavState.isSecondOpen()){
+            //If closed, hide the space
+            scope.actualPanel = undefined;
+          }
+          return;
+        }
+        //If clickng in other panel
+        scope.actualPanel = panel;
+        if(!globalNavState.isSecondOpen()){
+          globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
+        }
       };
 
       function getMetaDashboards() {

--- a/src/ui/public/chrome/directives/global_nav/global_nav.js
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.js
@@ -48,7 +48,7 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       scope.toggleGlobalNav = event => {
         event.preventDefault();
         globalNavState.setOpen(!globalNavState.isOpen());
-        if(globalNavState.isSecondOpen()){
+        if(globalNavState.isSecondOpen()) {
           globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
           scope.actualPanel = undefined;
         }
@@ -72,6 +72,19 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
         scope.actualPanel = panel;
         if(!globalNavState.isSecondOpen()){
           globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
+        }
+      };
+
+      /*
+      * Function that changes the CSS of the item that was clicked
+      */
+      scope.selectedItem = 0;
+      scope.itemClicked = ($index) => {
+        scope.selectedItem = $index;
+        //Close second nav if it was open
+        if(globalNavState.isSecondOpen()) {
+          globalNavState.setSecondOpen(!globalNavState.isSecondOpen());
+          scope.actualPanel = undefined;
         }
       };
 

--- a/src/ui/public/chrome/directives/global_nav/global_nav.less
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.less
@@ -26,6 +26,18 @@
     }
   }
 
+  &.is-second-nav-open {
+    width: @global-nav-open-width + @second-nav-open-width;
+
+    .app-title {
+      display: inline-block;
+    }
+
+    + .app-wrapper {
+      left: @global-nav-open-width + @second-nav-open-width;
+    }
+  }
+
   .logo-small,
   .logo {
     height: @global-nav-logo-height;
@@ -41,6 +53,20 @@
       background-color: #000;
     }
   }
+}
+
+.second-nav-content {
+
+  color: #fff;
+  font-size: 0.8em; /* 10.68px;*/
+  /*position: fixed;*/
+  bottom: 0px;
+  height: 100%;
+  width: 100%;
+  padding-left: 0px;
+  margin-left: @global-nav-open-width;
+  z-index: 1;
+
 }
 
   /**

--- a/src/ui/public/chrome/directives/global_nav/global_nav.less
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.less
@@ -69,6 +69,13 @@
 
 }
 
+/**
+* CSS when a panel is clicked
+**/
+.selected-item {
+  background-color: #f49e42;
+}
+
   /**
    * 1. Push main apps to the top and bottom buttons to the bottom.
    * 2. Fill height of global nav, but respect the height of the logo and {{appTitle}} text.

--- a/src/ui/public/chrome/services/global_nav_state.js
+++ b/src/ui/public/chrome/services/global_nav_state.js
@@ -17,6 +17,21 @@ modules.get('kibana')
       localStorage.set('kibana.isGlobalNavOpen', isOpen);
       $rootScope.$broadcast('globalNavState:change');
       return isOpen;
+    },
+
+    isSecondOpen: () => {
+      const isOpen = localStorage.get('kibana.isSecondNavOpen');
+      if (isOpen === null) {
+        // The global nav should default to being open for the initial experience.
+        return false;
+      }
+      return isOpen;
+    },
+
+    setSecondOpen: isOpen => {
+      localStorage.set('kibana.isSecondNavOpen', isOpen);
+      $rootScope.$broadcast('globalNavState:change');
+      return isOpen;
     }
   };
 });

--- a/src/ui/public/styles/variables/for-theme.less
+++ b/src/ui/public/styles/variables/for-theme.less
@@ -334,6 +334,7 @@
 
 // Global Nav ================================================================
 @global-nav-open-width: 180px;
+@second-nav-open-width: 200px;
 @global-nav-closed-width: 53px;
 @app-icon-height: 38px;
 @app-line-height: 24px;


### PR DESCRIPTION
PR adds these functionalities:

* Show default menu when Edit button is clicked
* Keep Edit mode when switching between dashboards
* Force login form when the Edit button is clicked
* Show a second navbar when a panel has subpanels
* Keep marked one panel when is clicked, changing its CSS