### PR TITLE
Fixed load dashboard when click on the second navbar

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -354,6 +354,8 @@ app.directive('dashboardApp', function (es, kbnIndex, Notifier, courier, AppStat
       };
 
       $scope.$emit('application.load');
+      //Always check and close the second nav if it was open
+      $scope.$root.closeSecondNav();
     }
   };
 });

--- a/src/ui/public/chrome/directives/global_nav/global_nav.html
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.html
@@ -45,7 +45,7 @@
           <!-- One level menu entry (no submenus) -->
           <span ng-if="panel.length">
             <a
-              class='global-nav-link__anchor' ng-href='#/dashboard/{{panel}}' ng-click="$root.itemClicked($index)">
+              class='global-nav-link__anchor' href='#/dashboard/{{panel}}'>
               <div class='global-nav-link__icon' ng-class="{ 'selected-item': $index == selectedItem }">
               <!-- testing icon -->
               <img class="global-nav-link__icon-image ng-scope"
@@ -83,7 +83,7 @@
               <ul style='list-style: none;'>
                 <li ng-repeat="(name, url) in actualPanel">
                   <a  class='global-nav-link__anchor'
-                    ng-href='#/dashboard/{{url}}' ng-click="$root.itemClicked($parent.$index)">
+                    href='#/dashboard/{{url}}'>
                     {{name}}</a>
                 </li>
               </ul>

--- a/src/ui/public/chrome/directives/global_nav/global_nav.js
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.js
@@ -79,10 +79,8 @@ module.directive('globalNav', (es, kbnIndex, globalNavState) => {
       * Function that changes the CSS of the item that was clicked
       */
       scope.selectedItem = 0;
-      scope.$root.  itemClicked = ($index) => {
+      scope.$root.itemClicked = ($index) => {
         scope.selectedItem = $index;
-        //Close second nav if it was open
-        scope.$root.closeSecondNav();
       };
 
       /*


### PR DESCRIPTION
PR fix the error than occurs when a dashboard of the second navbar is loaded. 

This problem occurs because when the second navbar hides, the "current" dashboards is rendering at the same time that the other dashboard is loading. The solution is change the logic when the second navbar closes.