### PR TITLE
Changed background color when Edit mode is active

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -215,8 +215,10 @@ app.directive('dashboardApp', function (es, kbnIndex, Notifier, courier, AppStat
         $scope.dashboardViewMode = newMode;
         if(newMode === DashboardViewMode.VIEW) {
           $scope.$root.showDefaultMenu = false;
+          $(".global-nav__links").css("background-color", "");
         } else if(newMode === DashboardViewMode.EDIT) {
           $scope.$root.showDefaultMenu = true;
+          $(".global-nav__links").css("background-color", "#999");
           //Close second nav
           $scope.$root.closeSecondNav();
         }


### PR DESCRIPTION
PR adds this functionality:
* When the Edit mode is active, the default menu of Kibana (Visualize, Discover...) change its background color in order to clarify the UI.
