### PR TITLE
Change labels of percentiles, percentiles rank and median

### DIFF
--- a/src/ui/public/agg_types/metrics/percentile_ranks.js
+++ b/src/ui/public/agg_types/metrics/percentile_ranks.js
@@ -17,8 +17,7 @@ export default function AggTypeMetricPercentileRanksProvider(Private) {
       const field = this.getField();
       const format = (field && field.format) || fieldFormats.getDefaultInstance('number');
       const label = this.params.customLabel || this.getFieldDisplayName();
-
-      return 'Percentile rank ' + format.convert(this.key, 'text') + ' of "' + label + '"';
+      return label + ' - ' + this.key + ' rank'
     }
   };
 

--- a/src/ui/public/agg_types/metrics/percentiles.js
+++ b/src/ui/public/agg_types/metrics/percentiles.js
@@ -14,7 +14,10 @@ export default function AggTypeMetricPercentilesProvider(Private) {
   const valueProps = {
     makeLabel: function () {
       const label = this.params.customLabel || this.getFieldDisplayName();
-      return ordinalSuffix(this.key) + ' percentile of ' + label;
+      if(this.params.customLabel && this.type.name === 'median'){
+        return label;
+      }
+      return label + ' - ' + this.key + '%';
     }
   };
 


### PR DESCRIPTION
PR adds this functionality:

- In order to clarify the labels when a percentiles (rank) or median is selected, the labels has been changed for others more intuitive.
