### PR TITLE
Add feature of panel-title-custom to Kibiter 5.6.0

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/panel/panel.html
+++ b/src/core_plugins/kibana/public/dashboard/panel/panel.html
@@ -1,12 +1,58 @@
 <div class="panel panel-default" ng-class="{'panel--edit-mode': !isViewOnlyMode()}" ng-switch on="panel.type" ng-if="savedObj || error">
   <div class="panel-heading">
-    <span
-      data-test-subj="dashboardPanelTitle"
-      class="panel-title"
-      aria-label="{{:: 'Dashboard panel: ' + savedObj.title }}"
-    >
-      {{::savedObj.title}}
-    </span>
+    <div class="panel-title" title="{{::savedObj.title}}">
+       <i
+         class="fa"
+         ng-class="savedObj.vis.type.icon"
+         aria-label="{{::savedObj.vis.type.title}} Icon"
+         title="{{::savedObj.vis.type.title}}">
+       </i>
+       <a class="action panel-title-edit" ng-hide="showFormTitle" ng-click="setTitle()">
+         <span ng-if="panel.title">{{panel.title}}</span>
+         <span ng-hide="panel.title">{{::savedObj.title}}</span>
+       </a>
+
+       <div ng-if="showFormTitle" >
+         <form class="inline-form" role="form">
+             <input type="text" name="title" ng-model="panel.title"
+               placeholder="{{::savedObj.title}}" input-focus
+               ng-keyup="maybeCancel($event, conf)"
+               class="form-control">
+         </form>
+       </div>
+       <div ng-if="showFormTitle" class="panel-title-edit" >
+         <kbn-tooltip text="Set Title" placement="bottom" append-to-body="1">
+           <button
+             ng-click="confirmTitle()"
+             class="btn btn-success"
+             aria-label="Confirm"
+             data-test-subj="confirmButton">
+             <span class="sr-only">Confirm</span>
+             <i aria-hidden="true" class="fa fa-save"></i>
+           </button>
+         </kbn-tooltip>
+         <kbn-tooltip text="Cancel Title" placement="bottom" append-to-body="1">
+           <button
+             ng-click="cancelTitle()"
+             class="btn btn-default"
+             aria-label="Cancel"
+             data-test-subj="cancelButton">
+             <span class="sr-only">Cancel</span>
+             <i aria-hidden="true" class="fa fa-times"></i>
+           </button>
+         </kbn-tooltip>
+         <kbn-tooltip text="Restore Title" placement="bottom" append-to-body="1">
+           <button
+             ng-click="resetTitle()"
+             class="btn btn-default"
+             aria-label="Undo"
+             data-test-subj="undoButton">
+             <span class="sr-only">Undo</span>
+             <i aria-hidden="true" class="fa fa-undo"></i>
+           </button>
+         </kbn-tooltip>
+       </div>
+     </div>
     <div class="kuiMicroButtonGroup">
       <a
         class="kuiMicroButton"

--- a/src/core_plugins/kibana/public/dashboard/panel/panel.js
+++ b/src/core_plugins/kibana/public/dashboard/panel/panel.js
@@ -125,6 +125,14 @@ uiModules
             $scope.saveState();
           };
 
+          if ($scope.uiState) {
+            $scope.panel.title = $scope.uiState.get('title');
+            // sync external uiState changes
+            var syncUIState = function () {$scope.panel.title = $scope.uiState.get('title');};
+            $scope.uiState.on('change', syncUIState);
+            $scope.$on('$destroy', function () {$scope.uiState.off('change', syncUIState);});
+          }
+
           $scope.addColumn = function addColumn(columnName) {
             $scope.savedObj.searchSource.get('index').popularizeField(columnName, 1);
             columnActions.addColumn($scope.panel.columns, columnName);
@@ -179,6 +187,27 @@ uiModules
        */
       $scope.isViewOnlyMode = () => {
         return $scope.dashboardViewMode === DashboardViewMode.VIEW || $scope.isFullScreenMode;
+      };
+
+      $scope.setTitle = function () {
+        $scope.showFormTitle = !$scope.showFormTitle;
+        // save the panel title to the UI state
+        if (!_.isString($scope.panel.title)) $scope.panel.title = null;
+        $scope.uiState.set('title', $scope.panel.title);
+      };
+      $scope.confirmTitle = function () {$scope.setTitle();};
+      $scope.cancelTitle = function () {
+        $scope.panel.title = $scope.uiState.get('title');
+        $scope.showFormTitle = false;
+      };
+      $scope.resetTitle = function () {$scope.panel.title = null;};
+      $scope.maybeCancel = function ($event) {
+        const keyCodes = {
+          ESC: 27
+        };
+        if ($event.keyCode === keyCodes.ESC) {
+          $scope.cancelTitle();
+        }
       };
     }
   };

--- a/src/core_plugins/kibana/public/dashboard/styles/index.less
+++ b/src/core_plugins/kibana/public/dashboard/styles/index.less
@@ -132,6 +132,18 @@ dashboard-panel {
           font-size: 1.2em;
           margin-right: 4px;
         }
+
+        .panel-title-edit {
+          i {
+            opacity: 1;
+          }
+        }
+
+        &:hover {
+          .panel-title-edit {
+            cursor: pointer;
+          }
+        }
       }
 
       .panel-move:hover {


### PR DESCRIPTION
PR adds the functionality of panel-title-custom, the same that the 5.4.0 version:

https://github.com/grimoirelab/kibiter/tree/panel-title-custom-5.4.0
