### PR TITLE
Keep default menu if metadashboard is not defined

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -246,14 +246,18 @@ app.directive('dashboardApp', function ($injector) {
         $scope.topNavMenu = getTopNavConfig(newMode, navActions); // eslint-disable-line no-use-before-define
         dashboardState.switchViewMode(newMode);
         $scope.dashboardViewMode = newMode;
-        if(newMode === DashboardViewMode.VIEW) {
-          $scope.$root.showDefaultMenu = false;
-          $(".global-nav__links").css("background-color", "");
-        } else if(newMode === DashboardViewMode.EDIT) {
-          $scope.$root.showDefaultMenu = true;
-          $(".global-nav__links").css("background-color", "#999");
-          //Close second nav
-          $scope.$root.closeSecondNav();
+
+        //Check if metadashboard is loaded
+        if($scope.$root.loadedMetadashboard){
+          if(newMode === DashboardViewMode.VIEW) {
+            $scope.$root.showDefaultMenu = false;
+            $(".global-nav__links").css("background-color", "");
+          } else if(newMode === DashboardViewMode.EDIT) {
+            $scope.$root.showDefaultMenu = true;
+            $(".global-nav__links").css("background-color", "#999");
+            //Close second nav
+            $scope.$root.closeSecondNav();
+          }
         }
       }
 

--- a/src/ui/public/chrome/directives/global_nav/global_nav.js
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.js
@@ -91,8 +91,11 @@ module.directive('globalNav',  (es, kbnIndex, globalNavState) => {
         }
       };
 
+      //Default menu of Kibana by default
+      scope.$root.showDefaultMenu = true;
+      //get metadashboard
       es.search({
-       index: '.kibana',
+       index: kbnIndex,
        type: 'metadashboard',
        size: 5,
        body: {
@@ -104,6 +107,8 @@ module.directive('globalNav',  (es, kbnIndex, globalNavState) => {
        }
       }).then(function (resp) {
       	scope.$root.metadash = resp.hits.hits[0]._source;
+        scope.$root.loadedMetadashboard = true;
+        scope.$root.showDefaultMenu = false;
       })
 
     }


### PR DESCRIPTION
PR adds these functionality:
- When a Kibiter is empty, the default menu of Kibana appears.
- When the metadashboard is defined, the menu of selecting panels will be appear.