### PR TITLE
[docker] Change __PROJECT__ to $PROJECT_NAME variable

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -26,6 +26,7 @@ if [ "$1" = 'kibana' ]; then
 
         if [ "$PROJECT_NAME" != "" ]; then
                 sed -e "s/title: 'Kibana',$/title: '$PROJECT_NAME',/" -i /opt/kibana/src/core_plugins/kibana/index.js
+								sed -e "s|__PROJECT__|'$PROJECT_NAME'|" -i /opt/kibana/src/ui/views/chrome.jade
         fi
         if [ "$ELASTICSEARCH_USER" != "" ]; then
                 #elasticsearch.username: "user"


### PR DESCRIPTION
PRs adds the functionality of changing the string "\_\_PROJECT_\_\" to $PROJECT_NAME variable defined in the docker-compose.