### PR TITLE
Delete Clone button and all of its functionality

### DIFF
--- a/src/core_plugins/kibana/public/dashboard/dashboard.js
+++ b/src/core_plugins/kibana/public/dashboard/dashboard.js
@@ -282,25 +282,6 @@ app.directive('dashboardApp', function ($injector) {
       const navActions = {};
       navActions[TopNavIds.EXIT_EDIT_MODE] = () => onChangeViewMode(DashboardViewMode.VIEW);
       navActions[TopNavIds.ENTER_EDIT_MODE] = () => onChangeViewMode(DashboardViewMode.EDIT);
-      navActions[TopNavIds.CLONE] = () => {
-        const currentTitle = $scope.model.title;
-        const onClone = (newTitle) => {
-          dashboardState.savedDashboard.copyOnSave = true;
-          dashboardState.setTitle(newTitle);
-          return $scope.save().then(id => {
-            // If the save wasn't successful, put the original title back.
-            if (!id) {
-              $scope.model.title = currentTitle;
-              // There is a watch on $scope.model.title that *should* call this automatically but
-              // angular is failing to trigger it, so do so manually here.
-              dashboardState.setTitle(currentTitle);
-            }
-            return id;
-          });
-        };
-
-        showCloneModal(onClone, currentTitle, $rootScope, $compile);
-      };
       updateViewMode(dashboardState.getViewMode());
 
       // update root source when filters update

--- a/src/core_plugins/kibana/public/dashboard/top_nav/get_top_nav_config.js
+++ b/src/core_plugins/kibana/public/dashboard/top_nav/get_top_nav_config.js
@@ -13,7 +13,6 @@ export function getTopNavConfig(dashboardMode, actions) {
     case DashboardViewMode.VIEW:
       return [
         getShareConfig(),
-        getCloneConfig(actions[TopNavIds.CLONE]),
         getEditConfig(actions[TopNavIds.ENTER_EDIT_MODE])];
     case DashboardViewMode.EDIT:
       return [
@@ -66,14 +65,6 @@ function getViewConfig(action) {
 /**
  * @returns {kbnTopNavConfig}
  */
-function getCloneConfig(action) {
-  return {
-    key: 'clone',
-    description: 'Create a copy of your dashboard',
-    testId: 'dashboardClone',
-    run: action
-  };
-}
 
 /**
  * @returns {kbnTopNavConfig}

--- a/src/core_plugins/kibana/public/dashboard/top_nav/top_nav_ids.js
+++ b/src/core_plugins/kibana/public/dashboard/top_nav/top_nav_ids.js
@@ -4,6 +4,5 @@ export const TopNavIds = {
   OPTIONS: 'options',
   SAVE: 'save',
   EXIT_EDIT_MODE: 'exitEditMode',
-  ENTER_EDIT_MODE: 'enterEditMode',
-  CLONE: 'clone'
+  ENTER_EDIT_MODE: 'enterEditMode'
 };


### PR DESCRIPTION
PR deletes the Clone button and all of its functionality in order to avoid the copy of the dashboards.
