### PR TITLE
Add plugins folder intro the Zip building proccess

### DIFF
--- a/tasks/build/archives.js
+++ b/tasks/build/archives.js
@@ -1,5 +1,6 @@
 import { execFile } from 'child_process';
 import { all, fromNode } from 'bluebird';
+import { fromRoot } from '../../src/utils';
 
 export default (grunt) => {
   const { config, log } = grunt;
@@ -23,6 +24,7 @@ export default (grunt) => {
         tarArguments.push('--force-local');
       }
 
+      await exec('cp', ['-rf', fromRoot("plugins/"), fromRoot("build/" + buildName + "/.")]);
       await exec('tar', tarArguments);
     }
   }


### PR DESCRIPTION
PR adds the functionality of adding the plugins folder into the Zip building proccess in order to create releases of Kibiter.