### PR TITLE
Change name and version of the release

### DIFF
--- a/tasks/config/build.js
+++ b/tasks/config/build.js
@@ -19,5 +19,5 @@ export default (grunt) => {
 };
 
 function buildVersion(isRelease, version) {
-  return isRelease ? version : `${version}-SNAPSHOT`;
+  return isRelease ? version : `${version}-1`;
 }

--- a/tasks/config/platforms.js
+++ b/tasks/config/platforms.js
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
 
     const nodeShaSums = `${baseUri}/SHASUMS256.txt`;
 
-    const buildName = `kibana-${version}-${name}`;
+    const buildName = `kibiter-${version}-${name}`;
     const buildDir = resolve(rootPath, `build/${buildName}`);
 
     const tarName = `${buildName}.tar.gz`;
@@ -42,11 +42,11 @@ module.exports = function (grunt) {
     let rpmArch;
     if (name.match('linux')) {
       debArch = name.match('x86_64') ? 'amd64' : 'i386';
-      debName = `kibana-${version}-${debArch}.deb`;
+      debName = `kibiter-${version}-${debArch}.deb`;
       debPath = resolve(rootPath, `target/${debName}`);
 
       rpmArch = name.match('x86_64') ? 'x86_64' : 'i686';
-      rpmName = `kibana-${version}-${rpmArch}.rpm`;
+      rpmName = `kibiter-${version}-${rpmArch}.rpm`;
       rpmPath = resolve(rootPath, `target/${rpmName}`);
     }
     return {


### PR DESCRIPTION
By default, the releases are named 'kibana-version-os.tar.gz', this patch change the name to 'kibiter-version-os.tar.gz'.

