### PR TITLE
Fix bug when 'Results not found :(' appears

### DIFF
--- a/src/core_plugins/table_vis/public/table_vis.html
+++ b/src/core_plugins/table_vis/public/table_vis.html
@@ -1,7 +1,9 @@
 <div ng-controller="KbnTableVisController" class="table-vis">
   <div ng-if="!hasSomeRows && hasSomeRows !== null" class="table-vis-error">
     <h2 aria-hidden="true"><i aria-hidden="true" class="fa fa-meh-o"></i></h2>
-    <h4>No results found</h4>
+    <h4>No results found <br>
+      <a ng-click="doSearch($id)">Reset Search</a>
+    </h4>
   </div>
 
   <div ng-if="tableGroups" class="table-vis-container">


### PR DESCRIPTION
The button search disappeared when that message appears, now a link called 'Reset Search' refresh the table.

