### PR TITLE
Replace env variable KIBANA_DEFAULTAPPID in kibana.yml file

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -24,6 +24,10 @@ if [ "$1" = 'kibana' ]; then
                 sed -e "s|^# server.basePath: \"\".*$|server.basePath: \"$BASE_PATH\"|" -i /opt/kibana/config/kibana.yml
         fi
 
+        if [ "$KIBANA_DEFAULTAPPID" != "" ]; then
+                sed -i "s/^#kibana.defaultAppId.*/kibana.defaultAppId: $KIBANA_DEFAULTAPPID/" /opt/kibana/config/kibana.yml
+        fi
+
         if [ "$PROJECT_NAME" != "" ]; then
                 sed -e "s/'title': ''$/'title': '$PROJECT_NAME'/" -i /opt/kibana/src/core_plugins/kibana/public/kibana.js
         fi


### PR DESCRIPTION
Replace the default Kibana app variable based on an environment variable. This is
currently done one by one and should be synced with the current script used to
dockerize Kibana when we jump to 6.1.0
