### PR TITLE
Add SUPPORT_ADDRESS variable to the Docker entry point.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -85,6 +85,7 @@ RUN apt-get update && \
     echo 'elasticsearch.url: "https://localhost:9200"' >> /opt/kibana/config/kibana.yml && \
     echo 'elasticsearch.ssl.verificationMode: none' >> /opt/kibana/config/kibana.yml && \
     echo 'searchguard.basicauth.enabled: true' >> /opt/kibana/config/kibana.yml && \
+    echo '#searchguard.basicauth.login.contact_email:' >> /opt/kibana/config/kibana.yml && \
 
     cd /root && \
     # cleanup to thin the final image

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -31,6 +31,10 @@ if [ "$1" = 'kibana' ]; then
                 sed -e "s|^#elasticsearch.password:.*$|elasticsearch.password: \"$ELASTICSEARCH_PASSWORD\"|" -i /opt/kibana/config/kibana.yml
         fi
 
+        if [ "$SUPPORT_ADDRESS" != "" ]; then
+                sed -e "s|^#searchguard.basicauth.login.contact_email:.*$|searchguard.basicauth.login.contact_email: \"$SUPPORT_ADDRESS\"|" -i /opt/kibana/config/kibana.yml
+        fi
+
 	set -- gosu kibana "$@"
 fi
 


### PR DESCRIPTION
The SUPPORT_ADDRESS allows to include the email address used from the Kibiter UI to link to the support service.

Example:
```
version: '3'
services:
 kibiter:
  image: f82c4d8d63d7
  links:
    - elasticsearch
  ports:
   - "5601:5601"
  environment:
   - PROJECT_NAME=Test20
   - NODE_OPTIONS=--max-old-space-size=3200
   - ELASTICSEARCH_URL=https://elasticsearch:9200
   - SUPPORT_ADDRESS=incoming+Project/support@incoming.gitlab.com
...
```