### PR TITLE
[docker] Fix the version of Kibiter plugins so they work with 6.1.0 v…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,23 +53,26 @@ RUN apt-get update && \
     cd /opt/kibana/plugins && \
     git clone https://github.com/dlumbrer/kbn_dotplot.git -b 6-dev && \
     cd kbn_dotplot && \
+    git checkout b2cb2e2b1ec1c878f0e1f30c3ccdf53d671b91e8 && \
     npm install  && \
     cd .. && \
     # Install polar plugin: https://github.com/dlumbrer/kbn_polar
     cd /opt/kibana/plugins && \
     git clone https://github.com/dlumbrer/kbn_polar.git -b 6-dev && \
     cd kbn_polar && \
+    git checkout d5c12750e9b922342371828c01693ffa8ae957b2 && \
     npm install  && \
     cd .. && \
     # Install radar plugin: https://github.com/dlumbrer/kbn_radar
     cd /opt/kibana/plugins && \
     git clone https://github.com/dlumbrer/kbn_radar.git -b 6-dev && \
     cd kbn_radar && \
+    git checkout c69104e17c7519b4a3ec40b24a7f4e5d8ce5eb2b && \
     npm install  && \
     cd .. && \
     # Install network plugin: https://dlumbrer.github.io/kbn_network/
     cd /opt/kibana/plugins && \
-    git clone https://github.com/dlumbrer/kbn_network.git network_vis -b 6-dev && \
+    git clone https://github.com/dlumbrer/kbn_network.git network_vis -b 6.2-dev && \
     cd network_vis && \
     npm install  && \
     cd .. && \


### PR DESCRIPTION
…ersion

Some of the upstream plugins just have a branch for kibana 6 development so
once they are updated to a new version, they don't work in some cases with
previous versions of Kibana.

This patch fix the version of the plugins using a specific commit for Kibiter 6.1.0:

https://github.com/dlumbrer/kbn_dotplot/commit/b2cb2e2b1ec1c878f0e1f30c3ccdf53d671b91e8
https://github.com/dlumbrer/kbn_polar/commit/d5c12750e9b922342371828c01693ffa8ae957b2
https://github.com/dlumbrer/kbn_radar/commit/c69104e17c7519b4a3ec40b24a7f4e5d8ce5eb2b
https://github.com/dlumbrer/kbn_network/ -> use 6.2-dev branch

<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `npm test && npm run build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
