### PR TITLE
Fix customizable credentials for kibiter

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -82,10 +82,6 @@ RUN apt-get update && \
     unzip searchguard-biter-6.1.0-10-3.zip && \
     cd .. && \
     # Add Search-Guard configuration to kibana.yml
-    echo 'server.host: 0.0.0.0' >> /opt/kibana/config/kibana.yml && \
-    echo 'elasticsearch.username: "kibanaserver"' >> /opt/kibana/config/kibana.yml && \
-    echo 'elasticsearch.password: "kibanaserver"' >> /opt/kibana/config/kibana.yml && \
-    echo 'elasticsearch.url: "https://localhost:9200"' >> /opt/kibana/config/kibana.yml && \
     echo 'elasticsearch.ssl.verificationMode: none' >> /opt/kibana/config/kibana.yml && \
     echo 'searchguard.basicauth.enabled: true' >> /opt/kibana/config/kibana.yml && \
     echo '#searchguard.basicauth.login.contact_email:' >> /opt/kibana/config/kibana.yml && \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -25,8 +25,11 @@ if [ "$1" = 'kibana' ]; then
         fi
 
         if [ "$ELASTICSEARCH_USER" != "" ]; then
-                #elasticsearch.username: "user"
-                #elasticsearch.password: "pass"
+                sed -e "s|^#elasticsearch.username:.*$|elasticsearch.username: \"$ELASTICSEARCH_USER\"|" -i /opt/kibana/config/kibana.yml
+                sed -e "s|^#elasticsearch.password:.*$|elasticsearch.password: \"$ELASTICSEARCH_PASSWORD\"|" -i /opt/kibana/config/kibana.yml
+	else
+                ELASTICSEARCH_USER="kibanaserver"
+                ELASTICSEARCH_PASSWORD="kibanaserver"
                 sed -e "s|^#elasticsearch.username:.*$|elasticsearch.username: \"$ELASTICSEARCH_USER\"|" -i /opt/kibana/config/kibana.yml
                 sed -e "s|^#elasticsearch.password:.*$|elasticsearch.password: \"$ELASTICSEARCH_PASSWORD\"|" -i /opt/kibana/config/kibana.yml
         fi


### PR DESCRIPTION
When custom credentials were set into the docker-compose file, both
sets of credentials (default ones and custom ones) were present into
the kibana.yml file. Now, only the proper set of credentials will be
into the config file.