### PR TITLE
Check if it is only one level of buckets in order to show "Others"

### DIFF
--- a/src/ui/public/vis/response_handlers/basic.js
+++ b/src/ui/public/vis/response_handlers/basic.js
@@ -51,21 +51,30 @@ const BasicResponseHandlerProvider = function (Private) {
         if (response.aggregations) {
           var aggs = response.aggregations[_.keys(response.aggregations)[0]];
           if (aggs.sum_other_doc_count) {
-            if (aggs.buckets[0][1]) {
-               // Unique count
-               aggs.buckets.push({
-                 '1': {"value": aggs.sum_other_doc_count},
-                 'key':'Others',
-                 'doc_count': aggs.sum_other_doc_count
-               });
-             }
-
-            else {
-                // Add another bucket with sum_other_doc_count
+            // Check that it is only a one level bucket
+            let oneLevel = true
+            _.keys(aggs.buckets[0]).forEach(function (key){
+              if(aggs.buckets[0][key].buckets){
+                oneLevel = false
+              }
+            });
+            if(oneLevel){
+              if (aggs.buckets[0][1]) {
+                // Unique count
                 aggs.buckets.push({
+                  '1': {"value": aggs.sum_other_doc_count},
                   'key':'Others',
                   'doc_count': aggs.sum_other_doc_count
                 });
+              }
+
+              else {
+                  // Add another bucket with sum_other_doc_count
+                  aggs.buckets.push({
+                    'key':'Others',
+                    'doc_count': aggs.sum_other_doc_count
+                  });
+              }
             }
           }
         }


### PR DESCRIPTION
There was a problem with one of our functionality called "others", that adds manually a bucket call "Others" in order to show the accumulated metric of the other fields that are not included in the bucket.

This functionality has sense only when there is "one level" of buckets, if you add more sub-buckets it does not has sense because is impossible to aggregate sth call other, also it has no sense in a visualization.

This PR adds this check and solve bugs like https://github.com/chaoss/grimoirelab-sigils/pull/230.