### PR TITLE
Collapse Kibana menu by default

### DIFF
--- a/src/ui/public/chrome/services/global_nav_state.js
+++ b/src/ui/public/chrome/services/global_nav_state.js
@@ -8,7 +8,7 @@ uiModules.get('kibana')
         const isOpen = localStorage.get('kibana.isGlobalNavOpen');
         if (isOpen === null) {
         // The global nav should default to being open for the initial experience.
-          return true;
+          return false;
         }
         return isOpen;
       },


### PR DESCRIPTION
We want to collapse by default the menu of Kibana, regarding to https://github.com/elastic/kibana/issues/12958#issuecomment-316344168, this is the way to collapse the menu by default (because they are not going to add this feature until Kibana 7)