### PR TITLE
Block kibana apps forcing redirection to /dashboard/Overview

### DIFF
--- a/src/core_plugins/console/public/console.js
+++ b/src/core_plugins/console/public/console.js
@@ -1,6 +1,8 @@
 import uiRoutes from 'ui/routes';
 import template from './index.html';
 
+import { redirectNonBitergiaUser } from 'ui/kibiter/hide_apps/redirect_non_bitergia_user'
+
 require('ace');
 require('ui-bootstrap-custom');
 
@@ -17,6 +19,9 @@ require('./src/directives/sense_welcome');
 
 
 uiRoutes.when('/dev_tools/console', {
+  resolve: {
+    isAllowedUser: redirectNonBitergiaUser
+  },
   controller: 'SenseController',
   template
 });

--- a/src/core_plugins/kibana/public/discover/controllers/discover.js
+++ b/src/core_plugins/kibana/public/discover/controllers/discover.js
@@ -31,6 +31,8 @@ import { migrateLegacyQuery } from 'ui/utils/migrateLegacyQuery';
 import { FilterManagerProvider } from 'ui/filter_manager';
 import { SavedObjectsClientProvider } from 'ui/saved_objects';
 
+import { redirectAnonymousUser } from 'ui/kibiter/hide_apps/redirect_anonymous_user'
+
 const app = uiModules.get('apps/discover', [
   'kibana/notify',
   'kibana/courier',
@@ -45,6 +47,7 @@ uiRoutes
     template: indexTemplate,
     reloadOnSearch: false,
     resolve: {
+      isAllowedUser: redirectAnonymousUser,
       ip: function (Promise, courier, config, $location, Private) {
         const State = Private(StateProvider);
         const savedObjectsClient = Private(SavedObjectsClientProvider);

--- a/src/core_plugins/kibana/public/management/index.js
+++ b/src/core_plugins/kibana/public/management/index.js
@@ -10,13 +10,21 @@ import { management } from 'ui/management';
 import { FeatureCatalogueRegistryProvider, FeatureCatalogueCategory } from 'ui/registry/feature_catalogue';
 import 'ui/kbn_top_nav';
 
+import { redirectNonBitergiaUser } from 'ui/kibiter/hide_apps/redirect_non_bitergia_user'
+
 uiRoutes
   .when('/management', {
+    resolve: {
+      isAllowedUser: redirectNonBitergiaUser
+    },
     template: landingTemplate
   });
 
 uiRoutes
   .when('/management/:section', {
+    resolve: {
+      isAllowedUser: redirectNonBitergiaUser
+    },
     redirectTo: '/management'
   });
 

--- a/src/core_plugins/kibana/public/visualize/editor/editor.js
+++ b/src/core_plugins/kibana/public/visualize/editor/editor.js
@@ -22,6 +22,8 @@ import { KibanaParsedUrl } from 'ui/url/kibana_parsed_url';
 import { absoluteToParsedUrl } from 'ui/url/absolute_to_parsed_url';
 import { migrateLegacyQuery } from 'ui/utils/migrateLegacyQuery';
 
+import { redirectAnonymousUser } from 'ui/kibiter/hide_apps/redirect_anonymous_user'
+
 uiRoutes
   .when(VisualizeConstants.CREATE_PATH, {
     template: editorTemplate,
@@ -39,7 +41,8 @@ uiRoutes
           .catch(courier.redirectWhenMissing({
             '*': '/visualize'
           }));
-      }
+      },
+      isAllowedUser: redirectAnonymousUser
     }
   })
   .when(`${VisualizeConstants.EDIT_PATH}/:id`, {
@@ -53,7 +56,8 @@ uiRoutes
             'index-pattern': '/management/kibana/objects/savedVisualizations/' + $route.current.params.id,
             'index-pattern-field': '/management/kibana/objects/savedVisualizations/' + $route.current.params.id
           }));
-      }
+      },
+      isAllowedUser: redirectAnonymousUser
     }
   });
 

--- a/src/core_plugins/kibana/public/visualize/index.js
+++ b/src/core_plugins/kibana/public/visualize/index.js
@@ -15,11 +15,16 @@ import { VisualizeListingController } from './listing/visualize_listing';
 import { VisualizeConstants } from './visualize_constants';
 import { FeatureCatalogueRegistryProvider, FeatureCatalogueCategory } from 'ui/registry/feature_catalogue';
 
+import { redirectAnonymousUser } from 'ui/kibiter/hide_apps/redirect_anonymous_user'
+
 uiRoutes
   .defaults(/visualize/, {
     requireDefaultIndex: true
   })
   .when(VisualizeConstants.LANDING_PAGE_PATH, {
+    resolve: {
+      isAllowedUser: redirectAnonymousUser
+    },
     template: visualizeListingTemplate,
     controller: VisualizeListingController,
     controllerAs: 'listingController',

--- a/src/core_plugins/kibana/public/visualize/wizard/wizard.js
+++ b/src/core_plugins/kibana/public/visualize/wizard/wizard.js
@@ -15,6 +15,8 @@ import visualizeWizardStep1Template from './step_1.html';
 import visualizeWizardStep2Template from './step_2.html';
 import { SavedObjectsClientProvider } from 'ui/saved_objects';
 
+import { redirectAnonymousUser } from 'ui/kibiter/hide_apps/redirect_anonymous_user'
+
 const module = uiModules.get('app/visualize', ['kibana/courier']);
 
 /********
@@ -23,10 +25,16 @@ const module = uiModules.get('app/visualize', ['kibana/courier']);
 
 // Redirect old route to new route.
 routes.when('/visualize/step/1', {
+  resolve: {
+    isAllowedUser: redirectAnonymousUser
+  },
   redirectTo: VisualizeConstants.WIZARD_STEP_1_PAGE_PATH,
 });
 
 routes.when(VisualizeConstants.WIZARD_STEP_1_PAGE_PATH, {
+  resolve: {
+    isAllowedUser: redirectAnonymousUser
+  },
   template: visualizeWizardStep1Template,
   controller: 'VisualizeWizardStep1',
 });
@@ -183,6 +191,9 @@ module.controller('VisualizeWizardStep1', function ($scope, $route, kbnUrl, time
 // NOTE: Accessing this route directly means the user has entered into the wizard UX without
 // selecting a Visualization type in step 1. So we want to redirect them to step 1, not step 2.
 routes.when('/visualize/step/2', {
+  resolve: {
+    isAllowedUser: redirectAnonymousUser
+  },
   redirectTo: VisualizeConstants.WIZARD_STEP_1_PAGE_PATH,
 });
 
@@ -198,7 +209,8 @@ routes.when(VisualizeConstants.WIZARD_STEP_2_PAGE_PATH, {
         fields: ['title'],
         perPage: 10000
       }).then(response => response.savedObjects);
-    }
+    },
+    isAllowedUser: redirectAnonymousUser
   }
 });
 

--- a/src/core_plugins/timelion/public/app.js
+++ b/src/core_plugins/timelion/public/app.js
@@ -6,6 +6,8 @@ import { SavedObjectRegistryProvider } from 'ui/saved_objects/saved_object_regis
 import { notify } from 'ui/notify';
 import { timezoneProvider } from 'ui/vis/lib/timezone';
 
+import { redirectAnonymousUser } from 'ui/kibiter/hide_apps/redirect_anonymous_user'
+
 require('plugins/timelion/directives/cells/cells');
 require('plugins/timelion/directives/fixed_element');
 require('plugins/timelion/directives/fullscreen/fullscreen');
@@ -42,7 +44,8 @@ require('ui/routes')
           .catch(courier.redirectWhenMissing({
             'search': '/'
           }));
-      }
+      },
+      isAllowedUser: redirectAnonymousUser
     }
   });
 

--- a/src/ui/public/chrome/directives/global_nav/app_switcher/app_switcher.js
+++ b/src/ui/public/chrome/directives/global_nav/app_switcher/app_switcher.js
@@ -3,6 +3,9 @@ import { parse } from 'url';
 import { uiModules } from 'ui/modules';
 import appSwitcherTemplate from './app_switcher.html';
 
+import { redirectAnonymousUser } from 'ui/kibiter/hide_apps/hide_menu_items'
+import { hideMenuItems } from '../../../../kibiter/hide_apps/hide_menu_items';
+
 uiModules
   .get('kibana')
   .provider('appSwitcherEnsureNavigation', function () {
@@ -56,6 +59,8 @@ uiModules
         }
 
         this.links = $scope.chrome.getNavLinks();
+
+        hideMenuItems(this.links)
 
         // links don't cause full-navigation events in certain scenarios
         // so we force them when needed

--- a/src/ui/public/kibiter/hide_apps/hide_menu_items.js
+++ b/src/ui/public/kibiter/hide_apps/hide_menu_items.js
@@ -1,0 +1,17 @@
+export function hideMenuItems(items) {
+    const hideItemsById = (ids) => {
+        ids.forEach((id) => {
+            let found = items.find(function (item) {
+                return item.id === id;
+            });
+            items.splice(items.indexOf(found), 1);
+        })
+    }
+
+    let currentuser = JSON.parse(localStorage.getItem("sg_user"));
+    if (currentuser && currentuser.username === "readall") {
+        hideItemsById(["kibana:management", "kibana:dev_tools", "kibana:discover", "kibana:visualize", "kibana:dashboard", "timelion"])
+    } else if (currentuser && currentuser.username !== "bitergia") {
+        hideItemsById(["kibana:management", "kibana:dev_tools"])
+    }
+}

--- a/src/ui/public/kibiter/hide_apps/redirect_anonymous_user.js
+++ b/src/ui/public/kibiter/hide_apps/redirect_anonymous_user.js
@@ -1,0 +1,7 @@
+export function redirectAnonymousUser() {
+    let currentuser = JSON.parse(localStorage.getItem("sg_user"));
+    if (currentuser && currentuser.username === "readall") {
+        window.location.replace(window.location.href.split("app/")[0] + "app/kibana#/dashboard/Overview")
+    }
+    return true
+}

--- a/src/ui/public/kibiter/hide_apps/redirect_non_bitergia_user.js
+++ b/src/ui/public/kibiter/hide_apps/redirect_non_bitergia_user.js
@@ -1,0 +1,7 @@
+export function redirectNonBitergiaUser() {
+    let currentuser = JSON.parse(localStorage.getItem("sg_user"));
+    if (currentuser && currentuser.username !== "bitergia") {
+        window.location.replace(window.location.href.split("app/")[0] + "app/kibana#/dashboard/Overview")
+    }
+    return true
+}


### PR DESCRIPTION
In case of the anonymous user, all the apps will be hidden and all the redirections will be to 
 dashboard/Overview, so the anonymous user just can see the dashboards. In the case of another user that is not the Bitergia admin, the Dev Tools app and the Management app will be hidden