### PR TITLE
Convert text parts of Bitergia logo to path

### DIFF
--- a/src/ui/public/images/bitergia-analytics.svg
+++ b/src/ui/public/images/bitergia-analytics.svg
@@ -14,8 +14,8 @@
    viewBox="0 0 141 51.000001"
    id="svg14569"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="bitergia-analytics.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="logobitergia (small).svg">
   <defs
      id="defs14571" />
   <sodipodi:namedview
@@ -26,16 +26,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="8.1492325"
-     inkscape:cx="98.972204"
+     inkscape:cx="74.491371"
      inkscape:cy="32.242306"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
      units="px"
-     inkscape:window-width="3200"
-     inkscape:window-height="1671"
-     inkscape:window-x="0"
-     inkscape:window-y="55"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata14574">
@@ -45,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -221,17 +221,46 @@
          style="font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;font-size:25px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Medium';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
          id="path4171" />
     </g>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       x="48.127388"
-       y="1046.6687"
-       id="text15177-1"
-       sodipodi:linespacing="125%"><tspan
-         sodipodi:role="line"
-         x="48.127388"
-         y="1046.6687"
-         id="tspan15181-5"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1">analytics</tspan></text>
+    <g
+       aria-label="analytics"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="text15177-1">
+      <path
+         d="m 53.247388,1045.3287 q 0.66,0 1.16,-0.02 0.52,-0.04 0.86,-0.12 v -3.1 q -0.2,-0.1 -0.66,-0.16 -0.44,-0.08 -1.08,-0.08 -0.42,0 -0.9,0.06 -0.46,0.06 -0.86,0.26 -0.38,0.18 -0.64,0.52 -0.26,0.32 -0.26,0.86 0,1 0.64,1.4 0.64,0.38 1.74,0.38 z m -0.16,-9.32 q 1.12,0 1.88,0.3 0.78,0.28 1.24,0.82 0.48,0.52 0.68,1.26 0.2,0.72 0.2,1.6 v 6.5 q -0.24,0.04 -0.68,0.12 -0.42,0.06 -0.96,0.12 -0.54,0.06 -1.18,0.1 -0.62,0.06 -1.24,0.06 -0.88,0 -1.62,-0.18 -0.74,-0.18 -1.28,-0.56 -0.54,-0.4 -0.84,-1.04 -0.3,-0.64 -0.3,-1.54 0,-0.86 0.34,-1.48 0.36,-0.62 0.96,-1 0.6,-0.38 1.4,-0.56 0.8,-0.18 1.68,-0.18 0.28,0 0.58,0.04 0.3,0.02 0.56,0.08 0.28,0.04 0.48,0.08 0.2,0.04 0.28,0.06 v -0.52 q 0,-0.46 -0.1,-0.9 -0.1,-0.46 -0.36,-0.8 -0.26,-0.36 -0.72,-0.56 -0.44,-0.22 -1.16,-0.22 -0.92,0 -1.62,0.14 -0.68,0.12 -1.02,0.26 l -0.22,-1.54 q 0.36,-0.16 1.2,-0.3 0.84,-0.16 1.82,-0.16 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path842" />
+      <path
+         d="m 60.157076,1036.5687 q 0.64,-0.16 1.7,-0.34 1.06,-0.18 2.44,-0.18 1.24,0 2.06,0.36 0.82,0.34 1.3,0.98 0.5,0.62 0.7,1.5 0.2,0.88 0.2,1.94 v 5.84 h -1.86 v -5.44 q 0,-0.96 -0.14,-1.64 -0.12,-0.68 -0.42,-1.1 -0.3,-0.42 -0.8,-0.6 -0.5,-0.2 -1.24,-0.2 -0.3,0 -0.62,0.02 -0.32,0.02 -0.62,0.06 -0.28,0.02 -0.52,0.06 -0.22,0.04 -0.32,0.06 v 8.78 h -1.86 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path844" />
+      <path
+         d="m 75.161451,1045.3287 q 0.66,0 1.16,-0.02 0.52,-0.04 0.86,-0.12 v -3.1 q -0.2,-0.1 -0.66,-0.16 -0.44,-0.08 -1.08,-0.08 -0.42,0 -0.9,0.06 -0.46,0.06 -0.86,0.26 -0.38,0.18 -0.64,0.52 -0.26,0.32 -0.26,0.86 0,1 0.64,1.4 0.64,0.38 1.74,0.38 z m -0.16,-9.32 q 1.12,0 1.88,0.3 0.78,0.28 1.24,0.82 0.48,0.52 0.68,1.26 0.2,0.72 0.2,1.6 v 6.5 q -0.24,0.04 -0.68,0.12 -0.42,0.06 -0.96,0.12 -0.54,0.06 -1.18,0.1 -0.62,0.06 -1.24,0.06 -0.88,0 -1.62,-0.18 -0.74,-0.18 -1.28,-0.56 -0.54,-0.4 -0.84,-1.04 -0.3,-0.64 -0.3,-1.54 0,-0.86 0.34,-1.48 0.36,-0.62 0.96,-1 0.6,-0.38 1.4,-0.56 0.8,-0.18 1.68,-0.18 0.28,0 0.58,0.04 0.3,0.02 0.56,0.08 0.28,0.04 0.48,0.08 0.2,0.04 0.28,0.06 v -0.52 q 0,-0.46 -0.1,-0.9 -0.1,-0.46 -0.36,-0.8 -0.26,-0.36 -0.72,-0.56 -0.44,-0.22 -1.16,-0.22 -0.92,0 -1.62,0.14 -0.68,0.12 -1.02,0.26 l -0.22,-1.54 q 0.36,-0.16 1.2,-0.3 0.84,-0.16 1.82,-0.16 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path846" />
+      <path
+         d="m 85.191138,1046.8687 q -1.72,-0.04 -2.44,-0.74 -0.72,-0.7 -0.72,-2.18 v -12.48 l 1.86,-0.32 v 12.5 q 0,0.46 0.08,0.76 0.08,0.3 0.26,0.48 0.18,0.18 0.48,0.28 0.3,0.08 0.74,0.14 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path848" />
+      <path
+         d="m 86.319888,1048.6087 q 0.22,0.1 0.56,0.18 0.36,0.1 0.7,0.1 1.1,0 1.72,-0.5 0.62,-0.48 1.12,-1.58 -1.26,-2.4 -2.36,-5.08 -1.08,-2.7 -1.8,-5.46 h 2 q 0.22,0.9 0.52,1.94 0.32,1.04 0.7,2.14 0.38,1.1 0.82,2.2 0.44,1.1 0.92,2.12 0.76,-2.1 1.32,-4.16 0.56,-2.06 1.06,-4.24 h 1.92 q -0.72,2.94 -1.6,5.66 -0.88,2.7 -1.9,5.06 -0.4,0.9 -0.84,1.54 -0.42,0.66 -0.94,1.08 -0.52,0.42 -1.18,0.62 -0.64,0.2 -1.46,0.2 -0.22,0 -0.46,-0.04 -0.24,-0.02 -0.48,-0.08 -0.22,-0.04 -0.42,-0.1 -0.18,-0.06 -0.26,-0.1 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path850" />
+      <path
+         d="m 99.201763,1036.2687 h 3.939997 v 1.56 h -3.939997 v 4.8 q 0,0.78 0.12,1.3 0.12,0.5 0.36,0.8 0.24,0.28 0.599997,0.4 0.36,0.12 0.84,0.12 0.84,0 1.34,-0.18 0.52,-0.2 0.72,-0.28 l 0.36,1.54 q -0.28,0.14 -0.98,0.34 -0.7,0.22 -1.6,0.22 -1.059997,0 -1.759997,-0.26 -0.68,-0.28 -1.1,-0.82 -0.42,-0.54 -0.6,-1.32 -0.16,-0.8 -0.16,-1.84 v -9.28 l 1.86,-0.32 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path852" />
+      <path
+         d="m 107.36864,1046.6687 h -1.86 v -10.4 h 1.86 z m -0.94,-12.28 q -0.5,0 -0.86,-0.32 -0.34,-0.34 -0.34,-0.9 0,-0.56 0.34,-0.88 0.36,-0.34 0.86,-0.34 0.5,0 0.84,0.34 0.36,0.32 0.36,0.88 0,0.56 -0.36,0.9 -0.34,0.32 -0.84,0.32 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path854" />
+      <path
+         d="m 115.10676,1046.9087 q -1.26,0 -2.22,-0.4 -0.94,-0.4 -1.6,-1.12 -0.64,-0.72 -0.96,-1.7 -0.32,-1 -0.32,-2.2 0,-1.2 0.34,-2.2 0.36,-1 1,-1.72 0.64,-0.74 1.56,-1.14 0.94,-0.42 2.08,-0.42 0.7,0 1.4,0.12 0.7,0.12 1.34,0.38 l -0.42,1.58 q -0.42,-0.2 -0.98,-0.32 -0.54,-0.12 -1.16,-0.12 -1.56,0 -2.4,0.98 -0.82,0.98 -0.82,2.86 0,0.84 0.18,1.54 0.2,0.7 0.6,1.2 0.42,0.5 1.06,0.78 0.64,0.26 1.56,0.26 0.74,0 1.34,-0.14 0.6,-0.14 0.94,-0.3 l 0.26,1.56 q -0.16,0.1 -0.46,0.2 -0.3,0.08 -0.68,0.14 -0.38,0.08 -0.82,0.12 -0.42,0.06 -0.82,0.06 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path856" />
+      <path
+         d="m 122.30364,1045.3287 q 1.14,0 1.68,-0.3 0.56,-0.3 0.56,-0.96 0,-0.68 -0.54,-1.08 -0.54,-0.4 -1.78,-0.9 -0.6,-0.24 -1.16,-0.48 -0.54,-0.26 -0.94,-0.6 -0.4,-0.34 -0.64,-0.82 -0.24,-0.48 -0.24,-1.18 0,-1.38 1.02,-2.18 1.02,-0.82 2.78,-0.82 0.44,0 0.88,0.06 0.44,0.04 0.82,0.12 0.38,0.06 0.66,0.14 0.3,0.08 0.46,0.14 l -0.34,1.6 q -0.3,-0.16 -0.94,-0.32 -0.64,-0.18 -1.54,-0.18 -0.78,0 -1.36,0.32 -0.58,0.3 -0.58,0.96 0,0.34 0.12,0.6 0.14,0.26 0.4,0.48 0.28,0.2 0.68,0.38 0.4,0.18 0.96,0.38 0.74,0.28 1.32,0.56 0.58,0.26 0.98,0.62 0.42,0.36 0.64,0.88 0.22,0.5 0.22,1.24 0,1.44 -1.08,2.18 -1.06,0.74 -3.04,0.74 -1.38,0 -2.16,-0.24 -0.78,-0.22 -1.06,-0.34 l 0.34,-1.6 q 0.32,0.12 1.02,0.36 0.7,0.24 1.86,0.24 z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:'Ubuntu, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1"
+         id="path858" />
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
Analytics text in Bitergia's logo was using a invalid typography. To fix this problem we have converted this section into a drawn path.