### PR TITLE
Fix bug with items that have just one subitem inside

### DIFF
--- a/src/ui/public/kbn_top_nav/kbn_top_nav.html
+++ b/src/ui/public/kbn_top_nav/kbn_top_nav.html
@@ -31,7 +31,7 @@
           {{ descriptionContent }}
         </div>
       </div>
-      <div class="col-md-2" ng-repeat="(i, column) in currentPanelsons">
+      <div class="col-md-2" ng-repeat="(i, column) in currentPanelsons track by $index">
         <div class="kibiterLocalDropdownTitle" ng-if="i === 0">{{parentDashboard.title}}</div>
         <div style="height: 25px" ng-if="i !== 0"></div>
         <div>


### PR DESCRIPTION
AngularJS does not allow to use duplicate keys in the `ng-repeat` expression, in our case, when we have just one item, the 3 columns left are with the key `undefined`, so AngularJS translate that as a duplicate key, the solution is simple and is provided by the docs:

https://docs.angularjs.org/error/ngRepeat/dupes