### PR TITLE
[docker] Add ruby-rake installation to default version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && \
 
     # install kibiter
     # gems needed in Kibana > 5.x to build binary packages
+    gem install rake && \
     gem install ffi && \
     gem install fpm -v 1.5.0 && \
     gem install pleaserun -v 0.0.24 && \


### PR DESCRIPTION
The same fix than https://github.com/Bitergia/grimoirelab-kibiter-finos/pull/2

---

In order to avoid an error when installing ruby-npm, the installation of rake is necessary.


This is the error:
```
ERROR:  Error installing fpm:
	ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.3.0/gems/childprocess-1.0.1/ext
/usr/bin/ruby2.3 mkrf_conf.rb

current directory: /var/lib/gems/2.3.0/gems/childprocess-1.0.1/ext
/usr/bin/ruby2.3 -rubygems /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake RUBYARCHDIR=/var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/childprocess-1.0.1 RUBYLIBDIR=/var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/childprocess-1.0.1
/usr/bin/ruby2.3: No such file or directory -- /usr/share/rubygems-integration/all/gems/rake-10.5.0/bin/rake (LoadError)

rake failed, exit code 1

```
