### PR TITLE
Add custom labeling for percentiles to Kibiter 6.8.6

### DIFF
--- a/src/ui/public/agg_types/metrics/percentile_ranks.js
+++ b/src/ui/public/agg_types/metrics/percentile_ranks.js
@@ -35,7 +35,7 @@ const valueProps = {
     const label = this.params.customLabel || this.getFieldDisplayName();
 
     return i18n.translate('common.ui.aggTypes.metrics.percentileRanks.valuePropsLabel', {
-      defaultMessage: 'Percentile rank {format} of "{label}"',
+      defaultMessage: '{label} - {format} rank',
       values: { format: format.convert(this.key, 'text'), label }
     });
   }

--- a/src/ui/public/agg_types/metrics/percentiles.js
+++ b/src/ui/public/agg_types/metrics/percentiles.js
@@ -28,8 +28,14 @@ import { i18n } from '@kbn/i18n';
 const valueProps = {
   makeLabel: function () {
     const label = this.params.customLabel || this.getFieldDisplayName();
+    if(this.params.customLabel && this.type.name === 'median'){
+      return i18n.translate('common.ui.aggTypes.metrics.percentiles.valuePropsLabel', {
+        defaultMessage: '{label}',
+        values: { label }
+      });
+    }
     return i18n.translate('common.ui.aggTypes.metrics.percentiles.valuePropsLabel', {
-      defaultMessage: '{percentile} percentile of {label}',
+      defaultMessage: '{label} - {percentile} %',
       values: { percentile: ordinalSuffix(this.key), label }
     });
   }


### PR DESCRIPTION
The same change that in the 6.1.4 version, just modifies the text of the percentiles and percentiles rank in order to clarify the result of the metrics to the user.

