### PR TITLE
Delete clone button and functionality in Kibiter 6.8.6

### DIFF
--- a/src/legacy/core_plugins/kibana/public/dashboard/dashboard_app.js
+++ b/src/legacy/core_plugins/kibana/public/dashboard/dashboard_app.js
@@ -409,27 +409,6 @@ app.directive('dashboardApp', function ($injector) {
         );
         showSaveModal(dashboardSaveModal);
       };
-      navActions[TopNavIds.CLONE] = () => {
-        const currentTitle = dashboardStateManager.getTitle();
-        const onClone = (newTitle, isTitleDuplicateConfirmed, onTitleDuplicate) => {
-          dashboardStateManager.savedDashboard.copyOnSave = true;
-          dashboardStateManager.setTitle(newTitle);
-          const saveOptions = {
-            confirmOverwrite: false,
-            isTitleDuplicateConfirmed,
-            onTitleDuplicate,
-          };
-          return save(saveOptions).then(({ id, error }) => {
-            // If the save wasn't successful, put the original title back.
-            if (!id || error) {
-              dashboardStateManager.setTitle(currentTitle);
-            }
-            return { id, error };
-          });
-        };
-
-        showCloneModal(onClone, currentTitle);
-      };
       navActions[TopNavIds.ADD] = () => {
         const addNewVis = () => {
           showNewVisModal(visTypes, { editorParams: [DashboardConstants.ADD_VISUALIZATION_TO_DASHBOARD_MODE_PARAM] });

--- a/src/legacy/core_plugins/kibana/public/dashboard/top_nav/get_top_nav_config.js
+++ b/src/legacy/core_plugins/kibana/public/dashboard/top_nav/get_top_nav_config.js
@@ -40,7 +40,6 @@ export function getTopNavConfig(dashboardMode, actions, hideWriteControls) {
           : [
             getFullScreenConfig(actions[TopNavIds.FULL_SCREEN]),
             getShareConfig(actions[TopNavIds.SHARE]),
-            getCloneConfig(actions[TopNavIds.CLONE]),
             getEditConfig(actions[TopNavIds.ENTER_EDIT_MODE]),
             getDocumentationConfig(actions[TopNavIds.DOCUMENTATION]),
           ]
@@ -116,22 +115,6 @@ function getViewConfig(action) {
       defaultMessage: 'Cancel editing and switch to view-only mode',
     }),
     testId: 'dashboardViewOnlyMode',
-    run: action
-  };
-}
-
-/**
- * @returns {kbnTopNavConfig}
- */
-function getCloneConfig(action) {
-  return {
-    key: i18n.translate('kbn.dashboard.topNave.cloneButtonAriaLabel', {
-      defaultMessage: 'clone',
-    }),
-    description: i18n.translate('kbn.dashboard.topNave.cloneConfigDescription', {
-      defaultMessage: 'Create a copy of your dashboard',
-    }),
-    testId: 'dashboardClone',
     run: action
   };
 }

--- a/src/legacy/core_plugins/kibana/public/dashboard/top_nav/top_nav_ids.js
+++ b/src/legacy/core_plugins/kibana/public/dashboard/top_nav/top_nav_ids.js
@@ -25,6 +25,5 @@ export const TopNavIds = {
   SAVE: 'save',
   EXIT_EDIT_MODE: 'exitEditMode',
   ENTER_EDIT_MODE: 'enterEditMode',
-  CLONE: 'clone',
   FULL_SCREEN: 'fullScreenMode',
 };


### PR DESCRIPTION
This PR, as in the 6.1.4 version, deletes the clone button in the dashboard an all of its functionality.

Signed-off-by: David Moreno <dmoreno@bitergia.com>

