### PR TITLE
Add support for making releases of Kibiter 6.8.6

### DIFF
--- a/src/dev/build/lib/build.js
+++ b/src/dev/build/lib/build.js
@@ -20,8 +20,8 @@
 import chalk from 'chalk';
 
 export function createBuild({ config, oss }) {
-  const name = oss ? 'kibana-oss' : 'kibana';
-  const logTag = oss ? chalk`{magenta [kibana-oss]}` : chalk`{cyan [  kibana  ]}`;
+  const name = oss ? 'kibiter' : 'kibana';
+  const logTag = oss ? chalk`{magenta [kibiter]}` : chalk`{cyan [  kibiter  ]}`;
 
   return new class Build {
     isOss() {
@@ -36,7 +36,7 @@ export function createBuild({ config, oss }) {
       return config.resolveFromRepo(
         'build',
         oss ? 'oss' : 'default',
-        `kibana-${config.getBuildVersion()}-${platform.getBuildName()}`,
+        `kibiter-${config.getBuildVersion()}-${platform.getBuildName()}`,
         ...args
       );
     }
@@ -45,7 +45,7 @@ export function createBuild({ config, oss }) {
       const ext = platform.isWindows() ? 'zip' : 'tar.gz';
       return config.resolveFromRepo(
         'target',
-        `${name}-${config.getBuildVersion()}-${platform.getBuildName()}.${ext}`
+        `${name}-${config.getBuildVersion()}-${platform.getBuildName()}-1.${ext}`
       );
     }
 

--- a/src/dev/build/tasks/create_archives_task.js
+++ b/src/dev/build/tasks/create_archives_task.js
@@ -19,6 +19,8 @@
 
 import path from 'path';
 import { mkdirp, compress } from '../lib';
+import execa from 'execa';
+import { fromRoot } from '../../../utils';
 
 export const CreateArchivesTask = {
   description: 'Creating the archives for each platform',
@@ -29,7 +31,7 @@ export const CreateArchivesTask = {
       const destination = build.getPlatformArchivePath(platform);
 
       log.info('archiving', source, 'to', destination);
-
+      await execa('cp', ['-rf', fromRoot("plugins/"), source + "/."]);
       await mkdirp(path.dirname(destination));
 
       switch (path.extname(destination)) {


### PR DESCRIPTION
This commit changes the name and includes the plugins folder in the kibiter release build process. Similar to the 6.1.4 version.


The command for making releases:

```
node scripts/build --oss --skip-os-packages --release --all-platforms
```
<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `npm test && npm run build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
-->
