### PR TITLE
Fix size of the GrimoireLab logo in the left menu

### DIFF
--- a/src/ui/public/chrome/directives/global_nav/global_nav.less
+++ b/src/ui/public/chrome/directives/global_nav/global_nav.less
@@ -4,8 +4,8 @@
   .kbnGlobalNav__logoBrand {
     &.kibana {
       background-image: url("~ui/images/grimoire-dashboard.svg");
-      background-position: 10px 14px;
-      background-size: 120px 42px;
+      background-position: 3px 10px;
+      background-size: 120px 50px;
       background-repeat: no-repeat;
       background-color: #000000;
     }


### PR DESCRIPTION
This commit fixes a bug related to the logo of the left menu. A
CSS change in order to use a better size and change the position
in order to see the Grimoire when the menu is collapsed.

Signed-off-by: David Moreno <dmoreno@bitergia.com>

<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `npm test && npm run build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
-->
