### PR TITLE
Fix layout bug of "No results found" text in tables

### DIFF
--- a/src/legacy/core_plugins/table_vis/public/table_vis.html
+++ b/src/legacy/core_plugins/table_vis/public/table_vis.html
@@ -37,12 +37,12 @@
       total-func="vis.params.totalFunc"
       ng-if="renderAgain && tableGroups">
     </kbn-agg-table-group>
-    <div ng-if="!hasSomeRows && hasSomeRows !== null" class="table-vis-error">
-      <div class="euiSpacer euiSpacer--l"></div>
-      <h2 aria-hidden="true"><i aria-hidden="true" class="fa fa-meh-o"></i></h2>
-      <h4>No results found <br>
-        <a ng-click="resetSearch()">Reset Search</a>
-      </h4>
-    </div>
+  </div>
+  <div ng-if="!hasSomeRows && hasSomeRows !== null" class="kbnDocTable__error">
+    <div class="euiSpacer euiSpacer--l"></div>
+    <h2 aria-hidden="true"><i aria-hidden="true" class="fa fa-meh-o"></i></h2>
+    <h4>No results found <br>
+      <a ng-click="resetSearch()">Reset Search</a>
+    </h4>
   </div>
 </div>


### PR DESCRIPTION
This commit fixes the bug of the tables when the tables don't show
information. The text now is centered.

This GIF shows the behavior:

![Peek 2020-03-23 17-23](https://user-images.githubusercontent.com/9249232/77338947-5d074400-6d2b-11ea-9400-c573a45d28d7.gif)


<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `npm test && npm run build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
-->
