### PR TITLE
Collapse Menu by default and delete dots in buttons in Firefox

### DIFF
--- a/src/ui/public/chrome/services/global_nav_state.js
+++ b/src/ui/public/chrome/services/global_nav_state.js
@@ -34,7 +34,7 @@ uiModules.get('kibana')
     let isOpen = false;
     newPlatformChrome.getIsCollapsed$().pipe(distinctUntilChanged()).subscribe(isCollapsed => {
       $rootScope.$evalAsync(() => {
-        isOpen = !isCollapsed;
+        isOpen = isCollapsed;
         $rootScope.$broadcast('globalNavState:change');
       });
     });
@@ -43,7 +43,7 @@ uiModules.get('kibana')
       isOpen: () => isOpen,
 
       setOpen: newValue => {
-        newPlatformChrome.setIsCollapsed(!newValue);
+        newPlatformChrome.setIsCollapsed(newValue);
       }
     };
   });

--- a/src/ui/public/kibiter/menu/kibiter_menu_style.less
+++ b/src/ui/public/kibiter/menu/kibiter_menu_style.less
@@ -18,6 +18,9 @@
     color: #F5F5F5;
 }
 
+.kibiterLocalMenuItem::-moz-focus-inner {
+    border: none !important;
+}
 
 .kibiterLocalDropdown {
     background-color: #525252 !important;


### PR DESCRIPTION
This PR's include two fixes:

- Collapse the left menu by default
- Delete the dots in the menu top when an item is clicked

This GIF shows the behavior:

![Peek 2020-03-24 12-39](https://user-images.githubusercontent.com/9249232/77422005-123e0880-6dcd-11ea-86bf-a244bd8c89ea.gif)
