### PR TITLE
[docker] Fix ELASTICSEARCH_URL to accept an array in the compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are four Docker images of Kibiter, they have the following tags:
 
 There are docker env variables for the secured image (`bitergia/kibiter:secured-v6.8.6-X`) that should be defined:
 
-- `ELASTICSEARCH_URL`: This env variable defines the URL of the ElasticSearch that Kibiter will connect.
+- `ELASTICSEARCH_URL`: This env variable defines the URL or URL's of the ElasticSearch that Kibiter will connect. This env variable must be an array of the endpoints, each one must be a string.
 - `BASE_PATH`: Enables you to specify a path to mount Kibiter at if you are running behind a proxy.
 - `PROJECT_NAME`: The name of the project that will be in the menu top bar and the page title.
 - `ELASTICSEARCH_USER`: Username that will use Kibiter to connect to ElasticSearch.

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -11,7 +11,7 @@ fi
 if [ "$1" = 'kibana' ]; then
 	if [ "$ELASTICSEARCH_URL" -o "$ELASTICSEARCH_PORT_9200_TCP" ]; then
 		: ${ELASTICSEARCH_URL:='http://elasticsearch:9200'}
-		sed -ri "s!^(\#\s*)?(elasticsearch\.hosts:).*!\2 ['$ELASTICSEARCH_URL']!" /opt/kibana/config/kibana.yml
+		sed -ri "s!^(\#\s*)?(elasticsearch\.hosts:).*!\2 $ELASTICSEARCH_URL!" /opt/kibana/config/kibana.yml
 	else
 		echo >&2 'warning: missing ELASTICSEARCH_PORT_9200_TCP or ELASTICSEARCH_URL'
 		echo >&2 '  Did you forget to --link some-elasticsearch:elasticsearch'


### PR DESCRIPTION
This should fix #141 


Tested in a compose using this env variable:

`- ELASTICSEARCH_URL=["https://elasticsearch:9200","https://0.0.0.0:9200"]`

The result in the kibana.yml is the following:

```
# The URLs of the Elasticsearch instances to use for all your queries.
elasticsearch.hosts: ["https://elasticsearch:9200","https://0.0.0.0:9200"]
```

And it launches well.

